### PR TITLE
Added gnome sort

### DIFF
--- a/sorting/README.md
+++ b/sorting/README.md
@@ -1,0 +1,28 @@
+<div align="center">
+	<img width="400" height="270" src="http://konpa.github.io/devicon/devicon.git/icons/javascript/javascript-original.svg">
+	<br>
+	<br>
+	<img src="https://cdn.abranhe.com/projects/algorithms/algorithms.svg" width="400px">
+  <br>
+	<br>
+  <p>Sorting ▲lgorithms implemented in Javascript</p>
+</div>
+
+## Contents
+
+- [Gnome Sort]()
+	Gnome sort is a sorting algorithm originally proposed by Dr. Hamid Sarbazi-Azad (Professor of Computer Engineering at Sharif University of Technology) in 2000 and called "stupid sort"[1] (not to be confused with bogosort), and then later on described by Dick Grune and named "gnome sort".
+	The algorithm always finds the first place where two adjacent elements are in the wrong order, and swaps them. It takes advantage of the fact that performing a swap can introduce a new out-of-order adjacent pair only next to the two swapped elements..
+
+ 
+
+## License
+
+This work is licensed under a [MIT License](https://github.com/abranhe/algorithms/blob/master/LICENSE)
+
+[![MIT IMG][mit-license]]((https://github.com/abranhe/algorithms/blob/master/LICENSE))
+
+To the extent possible under law, [Carlos Abraham](https://go.abranhe.com/github) has waived all copyright and related or neighboring rights to this work.
+
+
+[mit-license]: https://cdn.abraham.gq/projects/algorithms/mit-license.png

--- a/sorting/gnomesort.js
+++ b/sorting/gnomesort.js
@@ -1,0 +1,27 @@
+/*
+* Gnome sort is a sorting algorithm originally proposed by Dr. Hamid Sarbazi-Azad (Professor of Computer Engineering at Sharif University of Technology) in 2000 and called "stupid sort"[1] (not to be confused with bogosort), and then later on described by Dick Grune and named "gnome sort". The algorithm always finds the first place where two adjacent elements are in the wrong order, and swaps them. It takes advantage of the fact that performing a swap can introduce a new out-of-order adjacent pair only next to the two swapped elements.
+*/
+
+function gnomeSort(arr) 
+{
+    function moveBack(i) 
+  {
+        for( ; i > 0 && arr[i-1] > arr[i]; i--)
+        {
+            var t = arr[i];
+            arr[i] = arr[i-1];
+            arr[i-1] = t;
+        }
+    }
+    for (var i = 1; i < arr.length; i++) 
+    {
+        if (arr[i-1] > arr[i]) moveBack(i);
+    }
+    return arr;
+}
+
+var arra = [3, 0, 2, 5, -1, 4, 1]; 
+console.log("Original Array Elements"); 
+console.log(arra); 
+console.log("Sorted Array Elements"); 
+console.log(gnomeSort(arra));


### PR DESCRIPTION
Gnome sort is a sorting algorithm originally proposed by Dr. Hamid Sarbazi-Azad (Professor of Computer Engineering at Sharif University of Technology) in 2000 and called "stupid sort"[1] (not to be confused with bogosort), and then later on described by Dick Grune and named "gnome sort".
The algorithm always finds the first place where two adjacent elements are in the wrong order, and swaps them. It takes advantage of the fact that performing a swap can introduce a new out-of-order adjacent pair only next to the two swapped elements.