### PR TITLE
added comb sort

### DIFF
--- a/sorting/CombSort.js
+++ b/sorting/CombSort.js
@@ -1,0 +1,58 @@
+/*
+*The Comb Sort is a variant of the Bubble Sort. Like the Shell sort, the Comb Sort increases the gap used in comparisons and exchanges. Some implementations use the insertion sort once the gap is less than a certain amount. The basic idea is to eliminate turtles, or small values near the end of the list, since in a bubble sort these slow the sorting down tremendously. Rabbits, large values around the beginning of the list, do not pose a problem in bubble sort.  In bubble sort, when any two elements are compared, they always have a gap of 1. The basic idea of comb sort is that the gap can be much more than 1
+*/
+
+function combsort(arr)
+{
+ function is_array_sorted(arr) {
+      var sorted = true;
+      for (var i = 0; i < arr.length - 1; i++) {
+          if (arr[i] > arr[i + 1]) {
+              sorted = false;
+              break;
+          }
+      }
+      return sorted;
+  }
+ 
+  var iteration_count = 0;
+  var gap = arr.length - 2;
+  var decrease_factor = 1.25;
+ 
+  // Repeat iterations Until array is not sorted
+  
+  while (!is_array_sorted(arr)) 
+  {
+      // If not first gap  Calculate gap
+      if (iteration_count > 0)
+         gap = (gap == 1) ? gap : Math.floor(gap / decrease_factor);
+ 
+  // Set front and back elements and increment to a gap
+      var front = 0;
+      var back = gap;
+      while (back <= arr.length - 1) 
+      {
+          // Swap the elements if they are not ordered
+        
+          if (arr[front] > arr[back])
+          {
+              var temp = arr[front];
+              arr[front] = arr[back];
+              arr[back] = temp;
+          }
+ 
+          // Increment and re-run swapping
+        
+          front += 1;
+          back += 1;
+      }
+      iteration_count += 1;
+  }
+  return arr;
+}
+  
+ var arra = [3, 0, 2, 5, -1, 4, 1]; 
+console.log("Original Array Elements"); 
+console.log(arra); 
+console.log("Sorted Array Elements"); 
+console.log(combsort(arra));

--- a/sorting/README.md
+++ b/sorting/README.md
@@ -1,0 +1,28 @@
+<div align="center">
+	<img width="400" height="270" src="http://konpa.github.io/devicon/devicon.git/icons/javascript/javascript-original.svg">
+	<br>
+	<br>
+	<img src="https://cdn.abranhe.com/projects/algorithms/algorithms.svg" width="400px">
+  <br>
+	<br>
+  <p>Sorting ▲lgorithms implemented in Javascript</p>
+</div>
+
+## Contents
+
+- [Comb Sort]()
+	The Comb Sort is a variant of the Bubble Sort. Like the Shell sort, the Comb Sort increases the gap used in comparisons and exchanges. Some implementations use the insertion sort once the gap is less than a certain amount. The basic idea is to eliminate turtles, or small values near the end of the list, since in a bubble sort these slow the sorting down tremendously. Rabbits, large values around the beginning of the list, do not pose a problem in bubble sort. 
+	In bubble sort, when any two elements are compared, they always have a gap of 1. The basic idea of comb sort is that the gap can be much more than 1.
+
+ 
+
+## License
+
+This work is licensed under a [MIT License](https://github.com/abranhe/algorithms/blob/master/LICENSE)
+
+[![MIT IMG][mit-license]]((https://github.com/abranhe/algorithms/blob/master/LICENSE))
+
+To the extent possible under law, [Carlos Abraham](https://go.abranhe.com/github) has waived all copyright and related or neighboring rights to this work.
+
+
+[mit-license]: https://cdn.abraham.gq/projects/algorithms/mit-license.png


### PR DESCRIPTION
	The Comb Sort is a variant of the Bubble Sort. Like the Shell sort, the Comb Sort increases the gap used in comparisons and exchanges. Some implementations use the insertion sort once the gap is less than a certain amount. The basic idea is to eliminate turtles, or small values near the end of the list, since in a bubble sort these slow the sorting down tremendously. Rabbits, large values around the beginning of the list, do not pose a problem in bubble sort. 
	In bubble sort, when any two elements are compared, they always have a gap of 1. The basic idea of comb sort is that the gap can be much more than 1.